### PR TITLE
Add -q to cscope command

### DIFF
--- a/src/CscopeExecutor.ts
+++ b/src/CscopeExecutor.ts
@@ -136,7 +136,7 @@ export default class CscopeExecutor {
             cwd: this.exec_path + '/cscope',
             env: process.env};
 
-        let ret = spawnSync("cscope", ['-L' + level + targetText], cscopeExecConfig);
+        let ret = spawnSync("cscope", ['-q', '-L' + level + targetText], cscopeExecConfig);
         const fileList = ret.stdout.toString().split('\n');
         let list = [];
         fileList.forEach((line) =>{


### PR DESCRIPTION
We build database with -q to create fast symbol lookup so we should also have it while executing cscope.
Otherwise, we should have -d to avoid cscope updating cross-reference.