### PR TITLE
Introduce configuration of database_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Visual Studio Code C/C++ extension already supported tag parsing and symbol sear
     * Below settings are supported:
         * open_new_column - This flag controls how shall new .find window shall be opened. 'yes' means it shall be opened in a separate column while 'no' will open in a new tab. Default setting is no since v0.0.5.
         * engine_configurations.cscope.paths - This is an array of the paths where all source code files need to be parsed. It allows to include paths that outside of the vs code project. Default value is ${workspaceRoot}.
+        * engine_configurations.cscope.database_path - The path indicates where the cscope database should be built/and found. Default value is ${workspaceRoot}/.vscode/cscope as this was the default path before.

--- a/src/CscopeExecutor.ts
+++ b/src/CscopeExecutor.ts
@@ -44,21 +44,21 @@ function cmdRunner(cmd, args, option):Promise<any> {
 
 export default class CscopeExecutor {
     source_paths:string[];
-    exec_path:string;
+    database_path:string;
     outInf:OutputInterface;
     executorBusy:boolean;
 
-    constructor(source_paths:string[], exec_path:string, out:OutputInterface)
+    constructor(source_paths:string[], database_path:string, out:OutputInterface)
     {
         this.source_paths = source_paths;
-        this.exec_path = exec_path;
+        this.database_path = database_path;
         this.outInf = out;
         this.executorBusy = false;
     }
 
     private databaseReady():boolean {
         try {
-            fs.accessSync(this.exec_path + '/cscope/cscope.out', fs.constants.R_OK | fs.constants.W_OK);
+            fs.accessSync(this.database_path + '/cscope.out', fs.constants.R_OK | fs.constants.W_OK);
             return true;
         }
         catch (err)
@@ -70,7 +70,7 @@ export default class CscopeExecutor {
 
     private async checkToolSync():Promise<boolean> {
         const cscopeExecConfig = {
-            cwd: this.exec_path,
+            cwd: this.database_path,
             env: process.env};
 
         let result = await cmdRunner("cscope", ['-V'], cscopeExecConfig);
@@ -99,7 +99,7 @@ export default class CscopeExecutor {
 
     public checkTool():boolean{
         const cscopeExecConfig = {
-            cwd: this.exec_path,
+            cwd: this.database_path,
             env: process.env};
 
         const ret = spawnSync("cscope", ['-V'], cscopeExecConfig);
@@ -152,11 +152,10 @@ export default class CscopeExecutor {
                     let start = true;
                     this.source_paths.forEach((path) => {
                         const execConfig = {
-                            cwd: this.exec_path,
+                            cwd: this.database_path,
                             env: process.env};
                 
-                        let ret = spawnSync("mkdir", ['-p', 'cscope'], execConfig);
-                        ret = spawnSync("find", [path, '-type', 'f', '-name', '*.c', 
+                        let ret = spawnSync("find", [path, '-type', 'f', '-name', '*.c', 
                                         '-o', '-type', 'f', '-name', '*.h', 
                                         '-o', '-type', 'f', '-name', '*.cpp', 
                                         '-o', '-type', 'f', '-name', '*.cc', 
@@ -166,17 +165,17 @@ export default class CscopeExecutor {
                         }
                         else {
                             if (start) {
-                                fs.writeFileSync(this.exec_path + '/cscope/cscope.files', ret.stdout.toString());
+                                fs.writeFileSync(this.database_path + '/cscope.files', ret.stdout.toString());
                             }
                             else{
-                                fs.appendFileSync(this.exec_path + '/cscope/cscope.files', ret.stdout.toString());
+                                fs.appendFileSync(this.database_path + '/cscope.files', ret.stdout.toString());
                             }
                             start = false;
                         }
                     });
                 
                     const cscopeExecConfig = {
-                        cwd: this.exec_path + '/cscope',
+                        cwd: this.database_path,
                         env: process.env};
                     const ret = spawnSync("cscope", ['-b', '-q', '-k'], cscopeExecConfig);
                     if ((ret.stderr) && (ret.stderr.length > 0)) {
@@ -213,7 +212,7 @@ export default class CscopeExecutor {
         if (!this.executorBusy) {
 
             const cscopeExecConfig = {
-            cwd: this.exec_path + '/cscope',
+            cwd: this.database_path,
             env: process.env};
 
             let ret = spawnSync("cscope", ['-q', '-L' + level + targetText], cscopeExecConfig);

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -6,6 +6,8 @@ const spawnSync = require('child_process').spawnSync;
 import CscopeExecutor from './CscopeExecutor';
 import SymbolLocation from './SymbolLocation';
 
+var path = require('path');
+
 const SYMBOL_UNKNOWN = 0;
 const SYMBOL_FUNCTION = 1;
 const SYMBOL_DATATYPE = 2;
@@ -28,6 +30,8 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
             let list = [];
             fileList.forEach((line) =>{
                 let fileName = line.fileName;
+                if (!path.isAbsolute(fileName))
+                fileName = vscode.workspace.rootPath + '/' + fileName;
 //                console.log(fileName);
                 const lineNum = line.lineNum - 1;
                 let start_pos = new vscode.Position(lineNum, line.colStart);

--- a/src/RefProvider.ts
+++ b/src/RefProvider.ts
@@ -4,6 +4,9 @@ import * as vscode from 'vscode';
 
 import CscopeExecutor from './CscopeExecutor';
 import SymbolLocation from './SymbolLocation';
+import { PassThrough } from 'stream';
+
+var path = require('path');
 
 export class RefProvider implements vscode.ReferenceProvider {
 
@@ -25,6 +28,8 @@ export class RefProvider implements vscode.ReferenceProvider {
                 let list = [];
                 fileList.forEach((line) =>{
                     let fileName = line.fileName;
+                    if (!path.isAbsolute(fileName))
+                        fileName = vscode.workspace.rootPath + '/' + fileName;
 //                    console.log(fileName);
                     const lineNum = line.lineNum - 1;
                     let start_pos = new vscode.Position(lineNum, line.colStart);


### PR DESCRIPTION
Allow to overrule the default location of the cscope database.
Some projects (like u-boot and linux kernel) have a dedicated make target to
build the cscope data base, these projects do not generate the database
at the expected location.

Signed-off-by: Yves Deweerdt <ydew@newtec.eu>