### PR TITLE
External cscope database generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Visual Studio Code C/C++ extension already supported tag parsing and symbol sear
     * Below settings are supported:
         * open_new_column - This flag controls how shall new .find window shall be opened. 'yes' means it shall be opened in a separate column while 'no' will open in a new tab. Default setting is no since v0.0.5.
         * engine_configurations.cscope.paths - This is an array of the paths where all source code files need to be parsed. It allows to include paths that outside of the vs code project. Default value is ${workspaceRoot}.
+        * engine_configurations.cscope.database_path - The path indicates where the cscope database should be built/and found. Default value is ${workspaceRoot}/.vscode/cscope as this was the default path before.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Visual Studio Code C/C++ extension already supported tag parsing and symbol sear
         * open_new_column - This flag controls how shall new .find window shall be opened. 'yes' means it shall be opened in a separate column while 'no' will open in a new tab. Default setting is no since v0.0.5.
         * engine_configurations.cscope.paths - This is an array of the paths where all source code files need to be parsed. It allows to include paths that outside of the vs code project. Default value is ${workspaceRoot}.
         * engine_configurations.cscope.database_path - The path indicates where the cscope database should be built/and found. Default value is ${workspaceRoot}/.vscode/cscope as this was the default path before.
+        * engine_configurations.cscope.build_command - specify a build command for generating the cscope database. Default value is "", to use the built-int algorithm

--- a/src/CscopeExecutor.ts
+++ b/src/CscopeExecutor.ts
@@ -44,21 +44,21 @@ function cmdRunner(cmd, args, option):Promise<any> {
 
 export default class CscopeExecutor {
     source_paths:string[];
-    exec_path:string;
+    database_path:string;
     outInf:OutputInterface;
     executorBusy:boolean;
 
-    constructor(source_paths:string[], exec_path:string, out:OutputInterface)
+    constructor(source_paths:string[], database_path:string, out:OutputInterface)
     {
         this.source_paths = source_paths;
-        this.exec_path = exec_path;
+        this.database_path = database_path;
         this.outInf = out;
         this.executorBusy = false;
     }
 
     private databaseReady():boolean {
         try {
-            fs.accessSync(this.exec_path + '/cscope/cscope.out', fs.constants.R_OK | fs.constants.W_OK);
+            fs.accessSync(this.database_path + '/cscope.out', fs.constants.R_OK | fs.constants.W_OK);
             return true;
         }
         catch (err)
@@ -70,7 +70,7 @@ export default class CscopeExecutor {
 
     private async checkToolSync():Promise<boolean> {
         const cscopeExecConfig = {
-            cwd: this.exec_path,
+            cwd: this.database_path,
             env: process.env};
 
         let result = await cmdRunner("cscope", ['-V'], cscopeExecConfig);
@@ -99,7 +99,7 @@ export default class CscopeExecutor {
 
     public checkTool():boolean{
         const cscopeExecConfig = {
-            cwd: this.exec_path,
+            cwd: this.database_path,
             env: process.env};
 
         const ret = spawnSync("cscope", ['-V'], cscopeExecConfig);
@@ -152,11 +152,10 @@ export default class CscopeExecutor {
                     let start = true;
                     this.source_paths.forEach((path) => {
                         const execConfig = {
-                            cwd: this.exec_path,
+                            cwd: this.database_path,
                             env: process.env};
                 
-                        let ret = spawnSync("mkdir", ['-p', 'cscope'], execConfig);
-                        ret = spawnSync("find", [path, '-type', 'f', '-name', '*.c', 
+                        let ret = spawnSync("find", [path, '-type', 'f', '-name', '*.c', 
                                         '-o', '-type', 'f', '-name', '*.h', 
                                         '-o', '-type', 'f', '-name', '*.cpp', 
                                         '-o', '-type', 'f', '-name', '*.cc', 
@@ -166,17 +165,17 @@ export default class CscopeExecutor {
                         }
                         else {
                             if (start) {
-                                fs.writeFileSync(this.exec_path + '/cscope/cscope.files', ret.stdout.toString());
+                                fs.writeFileSync(this.database_path + '/cscope.files', ret.stdout.toString());
                             }
                             else{
-                                fs.appendFileSync(this.exec_path + '/cscope/cscope.files', ret.stdout.toString());
+                                fs.appendFileSync(this.database_path + '/cscope.files', ret.stdout.toString());
                             }
                             start = false;
                         }
                     });
                 
                     const cscopeExecConfig = {
-                        cwd: this.exec_path + '/cscope',
+                        cwd: this.database_path,
                         env: process.env};
                     const ret = spawnSync("cscope", ['-b', '-q', '-k'], cscopeExecConfig);
                     if ((ret.stderr) && (ret.stderr.length > 0)) {
@@ -213,7 +212,7 @@ export default class CscopeExecutor {
         if (!this.executorBusy) {
 
             const cscopeExecConfig = {
-            cwd: this.exec_path + '/cscope',
+            cwd: this.database_path,
             env: process.env};
 
             let ret = spawnSync("cscope", ['-q', '-L' + level + targetText], cscopeExecConfig);

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -6,6 +6,8 @@ const spawnSync = require('child_process').spawnSync;
 import CscopeExecutor from './CscopeExecutor';
 import SymbolLocation from './SymbolLocation';
 
+var path = require('path');
+
 const SYMBOL_UNKNOWN = 0;
 const SYMBOL_FUNCTION = 1;
 const SYMBOL_DATATYPE = 2;
@@ -28,6 +30,8 @@ export class DefinitionProvider implements vscode.DefinitionProvider {
             let list = [];
             fileList.forEach((line) =>{
                 let fileName = line.fileName;
+                if (!path.isAbsolute(fileName))
+                fileName = vscode.workspace.rootPath + '/' + fileName;
 //                console.log(fileName);
                 const lineNum = line.lineNum - 1;
                 let start_pos = new vscode.Position(lineNum, line.colStart);

--- a/src/RefProvider.ts
+++ b/src/RefProvider.ts
@@ -4,6 +4,9 @@ import * as vscode from 'vscode';
 
 import CscopeExecutor from './CscopeExecutor';
 import SymbolLocation from './SymbolLocation';
+import { PassThrough } from 'stream';
+
+var path = require('path');
 
 export class RefProvider implements vscode.ReferenceProvider {
 
@@ -25,6 +28,8 @@ export class RefProvider implements vscode.ReferenceProvider {
                 let list = [];
                 fileList.forEach((line) =>{
                     let fileName = line.fileName;
+                    if (!path.isAbsolute(fileName))
+                        fileName = vscode.workspace.rootPath + '/' + fileName;
 //                    console.log(fileName);
                     const lineNum = line.lineNum - 1;
                     let start_pos = new vscode.Position(lineNum, line.colStart);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,8 +73,9 @@ export function activate(context: vscode.ExtensionContext) {
         // Use the console to output diagnostic information (console.log) and errors (console.error)
         // This line of code will only be executed once when your extension is activated
         const database_path = getDatabasePath(configurations.engine_configurations[0].cscope.database_path);
+        const build_command = configurations.engine_configurations[0].cscope.build_command;
 
-        const executor = new CscopeExecutor(null, database_path, out);
+        const executor = new CscopeExecutor(null, database_path, build_command, out);
         const searchResult = new SearchResultProvider(executor);
     
         const providerRegistrations = vscode.Disposable.from(
@@ -133,6 +134,7 @@ const defaultConfig =
 '                "paths" : [\n' + 
 '                    "${workspaceRoot}"\n' + 
 '                ],\n' +
+'                "build_command" : "",\n' +
 '                "database_path" : "${workspaceRoot}/.vscode/cscope"\n' +
 '            }\n' +
 '        }\n' +
@@ -212,6 +214,7 @@ function buildDataBase()
     const sourcePaths = newConfig.engine_configurations[0].cscope.paths;
 
     const database_path = getDatabasePath(newConfig.engine_configurations[0].cscope.database_path);
+    const build_command = newConfig.engine_configurations[0].cscope.build_command;
 
     let paths = [];
     sourcePaths.forEach((path) => {
@@ -222,7 +225,8 @@ function buildDataBase()
     // start with linux command line since this is easier. Later shall change
     // to node api for file search.5
     // Now we are building the database
-    const executor = new CscopeExecutor(paths, database_path , out);
+
+    const executor = new CscopeExecutor(paths, database_path, build_command, out);
 
     if (executor.checkTool()) {
         executor.buildDataBase();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,8 @@ import CscopeExecutor from './CscopeExecutor';
 import SearchResultProvider, {openSearch} from './SearchResultProvider';
 import OutputInterface from './OutputInterface';
 
+var path = require('path');
+
 let configurations = null;
 const configPath = vscode.workspace.rootPath + '/.vscode/cscope_conf.json';
 
@@ -48,6 +50,16 @@ class VscodeOutput implements OutputInterface {
 
 const out = new VscodeOutput;
 
+function getDatabasePath(database_path_config:string)
+{
+    let expanded_path=database_path_config.replace('${workspaceRoot}', vscode.workspace.rootPath);
+    if (!path.isAbsolute(expanded_path))
+    {
+        return vscode.workspace.rootPath + '/' + expanded_path;
+    }
+    return expanded_path;
+}
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -60,8 +72,9 @@ export function activate(context: vscode.ExtensionContext) {
         configurations = JSON.parse(loadConfiguration());
         // Use the console to output diagnostic information (console.log) and errors (console.error)
         // This line of code will only be executed once when your extension is activated
-    
-        const executor = new CscopeExecutor(null, vscode.workspace.rootPath + '/.vscode', out);
+        const database_path = getDatabasePath(configurations.engine_configurations[0].cscope.database_path);
+
+        const executor = new CscopeExecutor(null, database_path, out);
         const searchResult = new SearchResultProvider(executor);
     
         const providerRegistrations = vscode.Disposable.from(
@@ -119,7 +132,8 @@ const defaultConfig =
 '            "cscope" : {\n' + 
 '                "paths" : [\n' + 
 '                    "${workspaceRoot}"\n' + 
-'                ]\n' + 
+'                ],\n' +
+'                "database_path" : "${workspaceRoot}/.vscode/cscope"\n' +
 '            }\n' +
 '        }\n' +
 '    ]\n' +
@@ -154,6 +168,16 @@ function loadConfiguration():string
         fs.writeFileSync(configPath, defaultConfig);
         configText = defaultConfig;
     }
+
+    let configuration = JSON.parse(configText);
+    const database_path = getDatabasePath(configuration.engine_configurations[0].cscope.database_path)
+    try{
+        fs.accessSync(database_path, fs.constants.R_OK | fs.constants.W_OK)
+    }
+    catch{
+        out.diagLog("cscope database path does not exist, creating new one");
+        fs.mkdirSync(database_path);
+    }
     return configText;
 }
 
@@ -165,6 +189,14 @@ function reloadConfiguration():any
 
     try {
         ret = JSON.parse(fs.readFileSync(configPath).toString());
+        const database_path = getDatabasePath(ret.engine_configurations[0].cscope.database_path)
+        try{
+            fs.accessSync(database_path, fs.constants.R_OK | fs.constants.W_OK)
+        }
+        catch{
+            out.diagLog("cscope database path does not exist, creating new one");
+            fs.mkdirSync(database_path);
+        }
     }
     catch {
         // Creating new one is not a good idea here
@@ -179,10 +211,7 @@ function buildDataBase()
     let newConfig = reloadConfiguration();
     const sourcePaths = newConfig.engine_configurations[0].cscope.paths;
 
-    const execConfig = {
-        cwd: vscode.workspace.rootPath,
-        env: process.env};
-    let ret = spawnSync("mkdir", ['-p', '.vscode'], execConfig);
+    const database_path = getDatabasePath(newConfig.engine_configurations[0].cscope.database_path);
 
     let paths = [];
     sourcePaths.forEach((path) => {
@@ -193,7 +222,7 @@ function buildDataBase()
     // start with linux command line since this is easier. Later shall change
     // to node api for file search.5
     // Now we are building the database
-    const executor = new CscopeExecutor(paths, vscode.workspace.rootPath + '/.vscode', out);
+    const executor = new CscopeExecutor(paths, database_path , out);
 
     if (executor.checkTool()) {
         executor.buildDataBase();


### PR DESCRIPTION
Some projects like u-boot and the linux kernel have a dedicated make target to generate the cscope database. In order to take advantage of that 3 changes were required:
- make the database_path configurable to point the CScopeExecutor to the right location
- allow to specify a build_command to replace the built-in cscope database generation mechanism
- the uri ended up on the root folder instead of a path relative to the workspace folder
