### PR TITLE
generate cscope.files based on a compile_commands.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ Visual Studio Code C/C++ extension already supported tag parsing and symbol sear
         * open_new_column - This flag controls how shall new .find window shall be opened. 'yes' means it shall be opened in a separate column while 'no' will open in a new tab. Default setting is no since v0.0.5.
         * engine_configurations.cscope.paths - This is an array of the paths where all source code files need to be parsed. It allows to include paths that outside of the vs code project. Default value is ${workspaceRoot}.
         * engine_configurations.cscope.database_path - The path indicates where the cscope database should be built/and found. Default value is ${workspaceRoot}/.vscode/cscope as this was the default path before.
-        * engine_configurations.cscope.build_command - specify a build command for generating the cscope database. Default value is "", to use the built-int algorithm
+        * engine_configurations.cscope.build_command - specify a build command for generating the cscope database. Default value is "", to use the built-int algorithm.
+        * engine_configurations.cscope.compile_commands_json - specify a compile_commands.json file to find used files and include files to generate the cscope.files from, if not empty, this overrules the standard algorithm to find the files to index. Default value is "".


### PR DESCRIPTION
the compile_commands.json file is parsed to find all files that are
compiled for the project and to find all include directories
specified for compilation. The header files found in all these include
directories are added to the cscope.files.